### PR TITLE
allow yield of each_existing_record if block_given?

### DIFF
--- a/lib/clone_kit/cloners/mongoid_merging_ruleset_cloner.rb
+++ b/lib/clone_kit/cloners/mongoid_merging_ruleset_cloner.rb
@@ -13,7 +13,10 @@ module CloneKit
       def clone_ids(ids, operation)
         @saved_id_map = {}
         initialize_cloner(operation)
-        apply_rules_and_save(find_and_merge_existing_records(ids))
+        result = find_and_merge_existing_records(ids) do |all_records|
+          yield all_records if block_given?
+        end
+        apply_rules_and_save(result)
       end
 
       protected
@@ -50,6 +53,8 @@ module CloneKit
 
         result = []
         skip = Set.new
+
+        yield all_records
 
         all_records.each_with_index do |record, i|
           next if skip.include?(record["_id"])

--- a/spec/clone_kit/cloners/mongoid_merging_ruleset_cloner_spec.rb
+++ b/spec/clone_kit/cloners/mongoid_merging_ruleset_cloner_spec.rb
@@ -5,12 +5,12 @@ require "clone_kit/cloners/mongoid_merging_ruleset_cloner"
 
 RSpec.describe CloneKit::Cloners::MongoidMergingRulesetCloner do
   let(:existing_ids) do
-    [
-      ExampleDoc.create!(name: "Merge Me"),
-      ExampleDoc.create!(name: "Merge Me", icon: "vader"),
-      ExampleDoc.create!(name: "Vader", icon: "vader")
-    ].map(&:id)
+    [doc1, doc2, doc3].map(&:id)
   end
+
+  let(:doc1) { ExampleDoc.create!(name: "Merge Me") }
+  let(:doc2) { ExampleDoc.create!(name: "Merge Me", icon: "vader") }
+  let(:doc3) { ExampleDoc.create!(name: "Vader", icon: "vader")}
 
   let(:operation) { CloneKit::Operation.new }
 
@@ -33,6 +33,10 @@ RSpec.describe CloneKit::Cloners::MongoidMergingRulesetCloner do
       run
       expect(CloneKit::SharedIdMap.new(operation.id).mapping("ExampleDoc").keys).to have(3).items.and \
         match_array(existing_ids)
+    end
+
+    it "yields all records given a block" do
+      expect { |b| subject.clone_ids(existing_ids, operation, &b) }.to yield_control.once
     end
 
     context "when merging by another field" do


### PR DESCRIPTION
I need this in order to fulfill the new business requirements for the tree cloning feature.  The tree cloner uses the ```MongoidMergingRulesetCloner```

The problem I have is that I need some place where I can get at _all_ the records in order to do a recursive node id mapping on the tree detail document _before_ any comparison or merge happens.

One would think that #compare would be an apt spot, however, if there are an odd number of records it is not.  See here: https://github.com/kapost/clone_kit/blob/51afe3a251bcad1085e0163aa8c44ee39c9c68b3/lib/clone_kit/cloners/mongoid_merging_ruleset_cloner.rb#L66

#apply_rules_and_save would also seem apt, but if there were any records merged, we only get the merged result and loose the old node ids, a problem for content field remapping.

#merge doesn't work because only records for which #compare returns truthy will be sent.

Right now I have this working by calling the tree node remapping method _twice_, in both #merge and #apply_rules_and_save.  This is ugly an inefficient.

I hope this explanation suffices and if not, I'm happy talk it through.  With this change, the implementation in the ```CustomFieldTreeDetailCloner``` would remove the duplicate call to map node ids and implement ```clone_ids``` as such:

```
def clone_ids(ids, operation)
  super do |all_records|
    all_records.each do |record|
      @merge_tool.generate_new_node_ids(record, fresh_id_map)
    end
  end
end
```
