### PR TITLE
Relocate id_generator assignment for rules

### DIFF
--- a/lib/clone_kit/cloners/active_record_ruleset_cloner.rb
+++ b/lib/clone_kit/cloners/active_record_ruleset_cloner.rb
@@ -45,8 +45,6 @@ module CloneKit
         attributes["id"] = new_id
 
         rules.each do |rule|
-          rule.id_generator = id_generator
-
           begin
             rule.fix(old_id, attributes)
           rescue StandardError => e
@@ -99,6 +97,7 @@ module CloneKit
 
         rules.each do |rule|
           rule.current_operation = @current_operation
+          rule.id_generator = id_generator
         end
       end
 

--- a/lib/clone_kit/cloners/mongoid_ruleset_cloner.rb
+++ b/lib/clone_kit/cloners/mongoid_ruleset_cloner.rb
@@ -82,8 +82,6 @@ module CloneKit
         attributes["_id"] = new_id
 
         rules.each do |rule|
-          rule.id_generator = id_generator
-
           begin
             rule.fix(old_id, attributes)
           rescue StandardError => e
@@ -129,6 +127,7 @@ module CloneKit
 
         rules.each do |rule|
           rule.current_operation = @current_operation
+          rule.id_generator = id_generator
         end
       end
 

--- a/lib/clone_kit/version.rb
+++ b/lib/clone_kit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CloneKit
-  VERSION = "0.4.0"
+  VERSION = "0.4.1"
 end


### PR DESCRIPTION
This updates where the id_generator is assigned for each rule.  This ensures that if another class extends one of these cloners, they do not need to worry about calling `rule.id_generator=` manually from `CustomCloner#clone_ids`.