### PR TITLE
[feature] Embedded model validation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [0.4.2](https://github.com/kapost/clone_kit/compare/v0.4.1...v0.4.2) - 2018-11-14
+### Added
+- CHANGELOG
+- Validation errors on embedded models when cloning

--- a/lib/clone_kit/version.rb
+++ b/lib/clone_kit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CloneKit
-  VERSION = "0.4.1"
+  VERSION = "0.4.2"
 end


### PR DESCRIPTION
Currently, when a newsroom fails to save due to errors on its embedded associations, we show an unhelpful error (e.g. "Custom fields is invalid"). his change elevates validation errors on embedded models.

<img width="1792" alt="screen shot 2018-11-14 at 10 50 57 am" src="https://user-images.githubusercontent.com/10552500/48494329-ab353a80-e7fb-11e8-8001-a23ec0f1459e.png">
