### PR TITLE
Fix CI pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,11 @@ jobs:
 
     steps:
       - checkout
-
+      - run:
+          name: Install deps
+          command: |
+            apt-get update
+            apt-get -y install netcat
       - restore_cache:
           keys:
             - bundle-v1-{{ arch }}-{{ .Branch }}-{{ checksum "clone_kit.gemspec" }}
@@ -30,7 +34,9 @@ jobs:
           key: bundle-v1-{{ arch }}-{{ .Branch }}-{{ checksum "clone_kit.gemspec" }}
           paths:
             - vendor/bundle
-
+      - run:
+          name: Wait for mongo
+          command: ./.circleci/wait_for_mongo.sh
       - run:
           name: Run Specs
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
         environment:
           POSTGRES_USER: circleci
           POSTGRES_DB: clone_kit_test
-      - image: kapost/mongo:3.0
+      - image: kapost/mongo:3.2
 
     working_directory: ~/clone_kit
 

--- a/.circleci/wait_for_mongo.sh
+++ b/.circleci/wait_for_mongo.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+until nc -z localhost 27017
+do
+    sleep 1
+done


### PR DESCRIPTION
## Overview
The clone_kit pipeline is sometimes too fast for the mongo container. Intermittently, the tests will start running before the mongo container is ready to accept connections. This PR adds a "wait-for-it" script for mongo. I also upgraded mongo to 3.2 as our app is no longer on 3.0.


## Jira Issue
https://kapost.atlassian.net/browse/DEVOPS-1182