### PR TITLE
[STUD-7245] Add method to delete redis keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.5.1](https://github.com/kapost/clone_kit/compare/v0.5.0...v0.5.1) - 2018-12-20
+- Added `SharedIdMap#delete` method for removing keys
+
 ## [0.5.0](https://github.com/kapost/clone_kit/compare/v0.4.2...v0.5.0) - 2018-11-20
 - Allow Specification dependencies to be assigned a proc
 

--- a/lib/clone_kit/shared_id_map.rb
+++ b/lib/clone_kit/shared_id_map.rb
@@ -39,6 +39,10 @@ module CloneKit
       end
     end
 
+    def delete(klass)
+      redis.del(hash_key(klass))
+    end
+
     def mapping(klass)
       Hash[redis.hgetall(hash_key(klass)).map { |k, v| [k, v] }]
     end

--- a/lib/clone_kit/version.rb
+++ b/lib/clone_kit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CloneKit
-  VERSION = "0.5.0"
+  VERSION = "0.5.1"
 end

--- a/spec/clone_kit/shared_id_map_spec.rb
+++ b/spec/clone_kit/shared_id_map_spec.rb
@@ -50,4 +50,23 @@ RSpec.describe CloneKit::SharedIdMap do
       expect(subject.mapping(ExampleDoc)).to have(3).items
     end
   end
+
+  describe "#delete" do
+    before do
+      subject.insert_many(
+        ExampleDoc,
+        Hash[
+          [
+            [id_generator.next, id_generator.next],
+            [id_generator.next, id_generator.next],
+            [id_generator.next, id_generator.next]
+          ]
+        ]
+      )
+    end
+
+    it "removes hash" do
+      expect { subject.delete(ExampleDoc) }.to change { subject.mapping(ExampleDoc) }.to({})
+    end
+  end
 end


### PR DESCRIPTION
### Overview
Adds `SharedIdMap#delete` to remove redis keys after they're no longer needed.

### Jira Story
https://kapost.atlassian.net/browse/STUD-7245