### PR TITLE
[STUD-7501] Fix nightly demo cloning jobs not being marked as complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.5.2](https://github.com/kapost/clone_kit/compare/v0.5.1...v0.5.2) - 2019-04-02
+- Do not hardcode classname in CloneKit::Strategies::Synchronous
+
 ## [0.5.1](https://github.com/kapost/clone_kit/compare/v0.5.0...v0.5.1) - 2018-12-20
 - Added `SharedIdMap#delete` method for removing keys
 

--- a/lib/clone_kit/strategies/synchronous.rb
+++ b/lib/clone_kit/strategies/synchronous.rb
@@ -22,7 +22,7 @@ module CloneKit
             already_cloned: operation.already_cloned + model_specs.map(&:model).map(&:to_s),
             id: operation.id,
             arguments: operation.arguments,
-            strategy: CloneKit::Strategies::Synchronous
+            strategy: self.class
           }
         )
       end

--- a/lib/clone_kit/version.rb
+++ b/lib/clone_kit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CloneKit
-  VERSION = "0.5.1"
+  VERSION = "0.5.2"
 end


### PR DESCRIPTION
In the demo environment's SupportUtils some nightly cloning jobs would never be marked as complete. They remained "in progress" even though the Sidekiq job was done. The problem was traced to a typo in clone_kit where the `CloneKit::Strategies::Synchronous` strategy was not calling its subclasses. This resulted in the [job completion callback in napa](https://github.com/kapost/napa/blob/master/app/services/clone_operation_service/updater.rb#L26) from never being run.