### PR TITLE
define arel_attributes_with_values_for_create internally

### DIFF
--- a/lib/clone_kit/version.rb
+++ b/lib/clone_kit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CloneKit
-  VERSION = "0.6.0"
+  VERSION = "0.6.1"
 end


### PR DESCRIPTION
The `arel_attributes_with_values_for_create` method in `ActiveRecord::AttributeMethods` was deprecated in rails 5.2 [here](https://github.com/rails/rails/commit/2f45157f2ebbe4f3fa43d3998b459c8eb9ec2b89). Hence clone kit brakes in application running on rails 5.2 and newer. In this PR I have defined `arel_attributes_with_values_for_create` internally, which is an exact copy of the functionality removed in rails.

Arel is a SQL AST manager for Ruby. The `arel_attributes_with_values_for_create` returns an Arel compatible object with the keys and values that need to be inserted into SQL DB using the InsertManager. 